### PR TITLE
Fixed wrong result from get_vertex_normal() function

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -410,7 +410,7 @@ class GetNormalVector(YAVNEBase):
 
         # Gather world space normal vectors associated with selected vertex.
         normals = set(
-            (model_matrix * mesh.loops[loop.index].normal).to_tuple()
+            (model_matrix.to_3x3().normalized() * mesh.loops[loop.index].normal).to_tuple()
             for loop in selected_vert.link_loops
         )
         self.normals = list(normals)


### PR DESCRIPTION
Fixed wrong result from get_vertex_normal() function. It caused a bug in 'Get' button - the resulting normal values were influenced by object's location. It had been giving the correct value only when object was in 0,0,0. Similar fix to: https://github.com/fedackb/yavne/pull/3