### PR TITLE
Fix crash on multiprocessing big targets

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -847,10 +847,11 @@ class MESH_OT_UpdateVertexNormals(MESH_OT_YAVNEBase):
         bm.verts.ensure_lookup_table()
         split_normals = multiprocessing.sharedctypes.Array(
             types.Vec3, len(mesh.loops), lock = False)
-
+        
         # Execute in parallel for large datasets if supported by the system.
         if len(bm.verts) > 5000 and not os.name == 'nt':
-
+            # Import the Process class (!)
+            from multiprocessing import Process
             # Create a team of worker processes.
             num_procs = utils.get_num_procs()
             for i in range(num_procs):


### PR DESCRIPTION
Prior to patch, if you try to "Update Vertex Normals" on a mesh that has more than 10 000 faces (or tris) yavne crashes, since the Process class is undefined.

The fix is simply to import Process from multiprocessing just prior to the use of the Process class.